### PR TITLE
Bug #31: Runtime Error

### DIFF
--- a/src/__main__.py
+++ b/src/__main__.py
@@ -80,7 +80,7 @@ def main():
     class EventScheduler(commands.Cog):
 
         def __init__(self):
-            self.schedule_events()
+            self.schedule_events.start()
             self.guild = None
 
         # Declare a function to unload the schedule_events task.


### PR DESCRIPTION
### Solution For #31 
Inside `def __init__()` of the EventScheduler, I called the `.start()` function to the Task loop rather than the Task loop itself.