### PR TITLE
Fixed poorly constructed class attribute  setters

### DIFF
--- a/src/classes/Course.py
+++ b/src/classes/Course.py
@@ -42,7 +42,7 @@ class Course():
     def day(self, day):
         if not isinstance(day, str):
             raise TypeError("Invalid day argument. Must be a string")
-        self._room = day
+        self._day = day
 
     @property
     def description(self):
@@ -52,7 +52,7 @@ class Course():
     def description(self, description):
         if not isinstance(description, str):
             raise TypeError("Invalid description argument. Must be a string")
-        self._room = description
+        self._description = description
         
     @property
     def start_time(self):
@@ -81,7 +81,7 @@ class Course():
     @room.setter
     def room(self, room):
         if not isinstance(room, str):
-            raise TypeError("Invalid day argument. Must be a string")
+            raise TypeError("Invalid room argument. Must be a string")
         self._room = room
     
     def parse_state(self, row_data, indexes):


### PR DESCRIPTION
Due to an oversight in constructing the Course class the attribute `_day` is never assigned a value, but instead `_room` is overwritten causing unexpected results. This is a simple fix and I am patching the main and develop branch.


`Traceback (most recent call last):
  File "/home/paulmolczanski/Documents/server/Discord-Bot/Discord-Bot_env/lib/python3.10/site-packages/discord/ext/tasks/__init__.py", line 125, in _loop
    raise exc
  File "/home/paulmolczanski/Documents/server/Discord-Bot/Discord-Bot_env/lib/python3.10/site-packages/discord/ext/tasks/__init__.py", line 101, in _loop
    await self.coro(*args, **kwargs)
  File "/home/paulmolczanski/Documents/server/Discord-Bot/src/events.py", line 171, in schedule_events
  File "/home/paulmolczanski/Documents/server/Discord-Bot/src/classes/Course.py", line 39, in day
    return self._day
AttributeError: 'Course' object has no attribute '_day'`

