### PR TITLE
Hotfix

### DIFF
--- a/src/classes/Course.py
+++ b/src/classes/Course.py
@@ -42,7 +42,7 @@ class Course():
     def day(self, day):
         if not isinstance(day, str):
             raise TypeError("Invalid day argument. Must be a string")
-        self._room = day
+        self._day = day
 
     @property
     def description(self):
@@ -52,7 +52,7 @@ class Course():
     def description(self, description):
         if not isinstance(description, str):
             raise TypeError("Invalid description argument. Must be a string")
-        self._room = description
+        self._description = description
         
     @property
     def start_time(self):
@@ -81,7 +81,7 @@ class Course():
     @room.setter
     def room(self, room):
         if not isinstance(room, str):
-            raise TypeError("Invalid day argument. Must be a string")
+            raise TypeError("Invalid room argument. Must be a string")
         self._room = room
     
     def parse_state(self, row_data, indexes):

--- a/src/events.py
+++ b/src/events.py
@@ -59,8 +59,6 @@ channel_id=channel_id)
     async def announce_assignments(self, due_dates, title: str, channel_id=None):
         """Sends a Discord message with assignment due dates based on a Context channel or Announcements channel ID in .env."""
 
-        # Preface with @everyone header.
-        message = "@everyone"
 
         # Instantiate the Embed.
         embedded_message = discord.Embed(title=title, colour=discord.Colour.from_rgb(160, 165, 25))
@@ -69,8 +67,6 @@ channel_id=channel_id)
 
         # Checks if a channel_id has been passed as an argument, then checks .env ANNOUNCEMENT_CHANNEL, then checks for announcements channel, otherwises returns error.
         if self.bot.get_channel(channel_id) != None:
-            # If a channel ID is provided that means the function was called on demand, meaning @everyone should be avoided.
-            message = ""
             channel = self.bot.get_channel(channel_id)
         elif self.bot.get_channel(int(ANNOUNCEMENT_CHANNEL)) != None:
             channel = self.bot.get_channel(int(ANNOUNCEMENT_CHANNEL))
@@ -108,7 +104,7 @@ channel_id=channel_id)
         embedded_message.add_field(name="\n\nAbout Me", value="I am part of the Lakehead CS 2021 Guild's Discord-Bot project! [Contributions on GitHub are welcome!](https://github.com/Paulmski/Discord-Bot/blob/main/CONTRIBUTING.md)")
     
         # Send the message to the announcements channel.
-        await channel.send(message, embed=embedded_message, delete_after=86400.0)
+        await channel.send("", embed=embedded_message, delete_after=86400.0)
 
     def format_assignment(self, assignment: Assignment):
         """Formats an Assignment object to a string that will be displayed in a Discord Embed."""


### PR DESCRIPTION
Due to an oversight in constructing the Course class the attribute `_day` is never assigned a value, but instead `_room` is overwritten causing unexpected results. This is a simple fix and I am patching the main and develop branch.
`Traceback (most recent call last):
  File "/home/paulmolczanski/Documents/server/Discord-Bot/Discord-Bot_env/lib/python3.10/site-packages/discord/ext/tasks/__init__.py", line 125, in _loop
    raise exc
  File "/home/paulmolczanski/Documents/server/Discord-Bot/Discord-Bot_env/lib/python3.10/site-packages/discord/ext/tasks/__init__.py", line 101, in _loop
    await self.coro(*args, **kwargs)
  File "/home/paulmolczanski/Documents/server/Discord-Bot/src/events.py", line 171, in schedule_events
  File "/home/paulmolczanski/Documents/server/Discord-Bot/src/classes/Course.py", line 39, in day
    return self._day
AttributeError: 'Course' object has no attribute '_day'`

