### PR TITLE
Bug #65: Fix to address weekday bug without Sheets change

### DIFF
--- a/src/classes/Assignment.py
+++ b/src/classes/Assignment.py
@@ -88,7 +88,7 @@ class Assignment():
 
         self.code = parsed_data["code"]
         self.name = parsed_data["assignment"]
-        self.due = datetime.strptime(parsed_data["due_date"], "%B %d, %Y")
+        self.due = datetime.strptime(parsed_data["due_date"], "%B %d")
         self.days_left = int(parsed_data["days_left"])
         self.course_name = parsed_data["course_name"]
         if parsed_data["notes"] != None:

--- a/src/events.py
+++ b/src/events.py
@@ -107,7 +107,7 @@ class FetchDate(commands.Cog):
         """Formats an Assignment object to a string that will be displayed in a Discord Embed."""
         # Parse the information from the assignment list.
         name = assignment.name
-        due_date = assignment.due.strftime("%A, %B %d")
+        due_date = assignment.due.replace(assignment.due.year + (datetime.now().year - 1900)).strftime("%A, %B %d")
         days_left = assignment.days_left
 
         # Change days_left to a different code block color depending on days left.


### PR DESCRIPTION
### Minor Changes
* In the `announce_assignments()` function's `format_assignment()`, replaced `datetime` object year property by adding the difference between current year and 1900 to 1900.
* Changed the state parsing for Assigment's `due` property back to its original `%B %d`.

### TODO:
* Change the Google Sheets format to the one without the years included, so that the `Assignment` object can properly parse the date inside the Sheet.
* This change is to be made to the main Google Sheet form if the pull request is accepted.

### Output
![image](https://user-images.githubusercontent.com/93796037/149184814-f09a9fd8-f566-4d6e-84f1-1fc9b50e679a.png)
**Output was created using a local copy of the Google Sheets, not the shared copy.**